### PR TITLE
Fix/report table : 재난 신고 상세보기 페이지 수정

### DIFF
--- a/src/components/report/DisasterDetailModal.tsx
+++ b/src/components/report/DisasterDetailModal.tsx
@@ -11,6 +11,7 @@ import {
   Button,
   CircularProgress,
   Paper,
+  Dialog,           // 추가
 } from '@mui/material';
 import AppDialog from '../AppDialog';
 import type { ReportDto, ReportStatusEN } from '../../types/report';
@@ -26,6 +27,9 @@ type Props = {
 export default function DisasterDetailModal({ open, onClose, data, onStatusChange }: Props) {
   const [status, setStatus] = React.useState<ReportStatusEN>(data.status);
   const [saving, setSaving] = React.useState(false);
+
+  // 원본 이미지 보기 다이얼로그 상태
+  const [imageOpen, setImageOpen] = React.useState(false);
 
   React.useEffect(() => {
     if (open) setStatus(data.status);
@@ -48,7 +52,6 @@ export default function DisasterDetailModal({ open, onClose, data, onStatusChang
     }
   };
 
-  /** 공통: 라벨+값 한 줄 */
   const InfoRow: React.FC<{ label: string; children: React.ReactNode }> = ({ label, children }) => (
     <Stack direction="row" spacing={2} alignItems="center" sx={{ minHeight: 32 }}>
       <Typography sx={{ width: { xs: 96, sm: 120 }, fontWeight: 700, fontSize: 15 }}>
@@ -58,7 +61,6 @@ export default function DisasterDetailModal({ open, onClose, data, onStatusChang
     </Stack>
   );
 
-  /** 공통: 박스 섹션 */
   const Section: React.FC<{ title: string; children: React.ReactNode }> = ({ title, children }) => (
     <Paper
       variant="outlined"
@@ -75,6 +77,93 @@ export default function DisasterDetailModal({ open, onClose, data, onStatusChang
       {children}
     </Paper>
   );
+
+  // 첨부 뷰어: 고정 박스(200x140) 안에 레터박스(잘림 없음). 디자인 유지.
+  const AttachmentBox: React.FC<{ imageUrl?: string | null; videoUrl?: string | null }> = ({
+    imageUrl,
+    videoUrl,
+  }) => {
+    if (videoUrl) {
+      return (
+        <Box
+          component="video"
+          src={videoUrl}
+          controls
+          preload="metadata"
+          sx={{
+            width: 200,
+            height: 140,
+            objectFit: 'contain',
+            borderRadius: 1.5,
+            border: '1px solid',
+            borderColor: 'divider',
+            display: 'block',
+            bgcolor: 'black',
+          }}
+        />
+      );
+    }
+    if (imageUrl) {
+      return (
+        <>
+          <Box
+            component="img"
+            src={imageUrl}
+            alt="신고 이미지"
+            onClick={() => setImageOpen(true)} // 클릭 시 확대
+            sx={{
+              width: 200,
+              height: 140,
+              objectFit: 'contain',
+              borderRadius: 1.5,
+              border: '1px solid',
+              borderColor: 'divider',
+              display: 'block',
+              bgcolor: 'background.default',
+              cursor: 'zoom-in',
+            }}
+          />
+          <Dialog
+            open={imageOpen}
+            onClose={() => setImageOpen(false)}
+            maxWidth="lg"
+          >
+            <Box
+              component="img"
+              src={imageUrl}
+              alt="원본 이미지"
+              sx={{
+                maxWidth: '90vw',
+                maxHeight: '90vh',
+                objectFit: 'contain', // 원본 비율 유지
+                display: 'block',
+              }}
+              onClick={() => setImageOpen(false)} // 클릭으로 닫기
+            />
+          </Dialog>
+        </>
+      );
+    }
+    return (
+      <Box
+        sx={{
+          p: 2,
+          border: '1px dashed',
+          borderColor: 'divider',
+          borderRadius: 1.5,
+          color: 'text.secondary',
+          textAlign: 'center',
+          width: 200,
+          height: 140,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        첨부 없음
+      </Box>
+    );
+  };
 
   return (
     <AppDialog
@@ -169,35 +258,7 @@ export default function DisasterDetailModal({ open, onClose, data, onStatusChang
 
         {/* 첨부 */}
         <Section title="첨부 자료">
-          {data.imageUrl ? (
-            <Box
-              component="img"
-              src={data.imageUrl}
-              alt="신고 이미지"
-              sx={{
-                width: 200,
-                height: 140,
-                objectFit: 'cover',
-                borderRadius: 1.5,
-                border: '1px solid',
-                borderColor: 'divider',
-                display: 'block',
-              }}
-            />
-          ) : (
-            <Box
-              sx={{
-                p: 2,
-                border: '1px dashed',
-                borderColor: 'divider',
-                borderRadius: 1.5,
-                color: 'text.secondary',
-                textAlign: 'center',
-              }}
-            >
-              첨부 없음
-            </Box>
-          )}
+          <AttachmentBox imageUrl={data.imageUrl as any} videoUrl={(data as any).videoUrl as any} />
         </Section>
 
         {/* 시간 */}

--- a/src/components/report/DisasterTable.tsx
+++ b/src/components/report/DisasterTable.tsx
@@ -183,7 +183,7 @@ export default function DisasterTable() {
       <div ref={topRef} />
 
       {/* 타이틀 단독 */}
-      <Typography variant="h5" sx={{ fontWeight: 700, mb: 1 }}>
+      <Typography variant="h5" sx={{ fontWeight: 800, mb: 1 }}>
         재난 신고 목록
       </Typography>
 

--- a/src/pages/report/DisasterHomePage.tsx
+++ b/src/pages/report/DisasterHomePage.tsx
@@ -112,11 +112,11 @@ export default function DisasterHomePage() {
             sx={{ mb: 2 }}
           >
             <Box>
-              <Typography variant="h5" sx={{ fontWeight: 800 }}>
-                당일 접수 현황
+              <Typography variant="h5" sx={{ fontWeight: 800, mb: 0.5 }}>
+                접수 현황
               </Typography>
               <Typography variant="body2" color="text.secondary">
-                {todayLabel} · {locationLabel} 기준
+                {locationLabel} 기준
               </Typography>
             </Box>
 

--- a/src/pages/report/MapPage.tsx
+++ b/src/pages/report/MapPage.tsx
@@ -36,9 +36,9 @@ export default function MapPage() {
         <Topbar />
         <Box sx={{ px:3, py:2 }}>
           <Stack spacing={0.5} sx={{ mb: 2 }}>
-            <Typography variant="h5" sx={{ fontWeight: 800 }}>당일 접수 현황</Typography>
+            <Typography variant="h5" sx={{ fontWeight: 800 }}>접수 현황</Typography>
             <Typography variant="body2" color="text.secondary">
-              {todayLabel} · {locationLabel} 기준
+              {locationLabel} 기준
             </Typography>
           </Stack>
 


### PR DESCRIPTION
- 재난 신고 상세보기 내 첨부자료에서 영상 안뜨는 문제 해결
- 사진 짤림 문제 해결
- 사진 클릭 시 원본 사이즈로 확대해서 볼 수 있는 기능 추가
- 당일 기준으로 표기하던 접수 현황을 처리 상태 기준으로 변경 